### PR TITLE
build: added linting config for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 node_modules/
 .env
 .docker

--- a/package.json
+++ b/package.json
@@ -76,6 +76,30 @@
     ],
     "verbose": true
   },
+  "eslintConfig": {
+    "root": true,
+    "parser": "@typescript-eslint/parser",
+    "plugins": [
+      "@typescript-eslint"
+    ],
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
+    ],
+    "rules": {
+      "@typescript-eslint/no-namespace": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ]
+    }
+  },
   "workspaces": [
     "packages/*",
     "tools/*"


### PR DESCRIPTION
`yarn build` was failing due to missing eslint config. I've added some sensible defaults to the root package.json. 