### PR TITLE
build: added prepack script to all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ws:test": "cd ${INIT_CWD} && jest --passWithNoTests",
     "ws:doctor": "cd ${INIT_CWD} && yarn dlx @yarnpkg/doctor",
     "ws:fix": "cd ${INIT_CWD} && prettier -w ./src && eslint \"src/**/*.ts\" --fix",
-    "ws:publish": "cd ${INIT_CWD} && yarn build && yarn npm publish --access public"
+    "ws:publish": "cd ${INIT_CWD} && yarn build && yarn npm publish --access public",
+    "ws:prepack": "cd ${INIT_CWD} && yarn clean && yarn compile"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "dependencies": {
     "lodash": "^4.17.21"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/packages/cypher/package.json
+++ b/packages/cypher/package.json
@@ -19,7 +19,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "peerDependencies": {
     "@aws-sdk/lib-dynamodb": "^3.54.0",

--- a/packages/dynamo-event-store/package.json
+++ b/packages/dynamo-event-store/package.json
@@ -19,7 +19,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "dependencies": {
     "@aws-sdk/lib-dynamodb": "^3.100.0",

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -17,7 +17,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "author": "Kevin O'Neill <kevin@weegigs.com.au>",
   "license": "MIT",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -19,7 +19,8 @@
     "lint": "yarn ws:lint",
     "doctor": "yarn ws:doctor",
     "fix": "yarn run ws:fix",
-    "publish": "yarn run ws:publish"
+    "publish": "yarn run ws:publish",
+    "prepack": "yarn run ws:prepack"
   },
   "dependencies": {
     "@effect-ts/core": "^0.60.1",


### PR DESCRIPTION
A `prepack` script has been added to all of the packages. This allows us to install directly from GitHub.